### PR TITLE
- #1: Refactored for warpjsUtils.sendPortalIndex().

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Releases
 
+## 1.2.8 - 2018-08-03
+
+- #1: Refactored for warpjsUtils.sendPortalIndex().
+
 ## 1.2.7 - 2018-08-01
 
 - Portal new header.

--- a/client/index.js
+++ b/client/index.js
@@ -1,6 +1,6 @@
 const warpjsUtils = require('@warp-works/warpjs-utils');
 
-const template = require('./templates/index.hbs');
+const template = require('./template.hbs');
 
 (($) => $(document).ready(() => warpjsUtils.getCurrentPageHAL($)
     .then((result) => {

--- a/client/template.hbs
+++ b/client/template.hbs
@@ -65,4 +65,4 @@
     </div>
 {{/partial}}
 
-{{> page-portal}}
+{{> portal-index-page}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@warp-works/warpjs-session-plugin",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Session Management plug-in for WarpJS",
   "main": "index.js",
   "scripts": {
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@quoin/expressjs-routes-info": ">=0.1.10",
-    "@warp-works/warpjs-utils": ">=1.2.0",
+    "@warp-works/warpjs-utils": ">=1.2.26",
     "body-parser": ">=1.17.2",
     "cookie-parser": ">= 1.4.3",
     "express": ">=4.0.0",
@@ -57,9 +57,9 @@
     "cookie-parser": "1.4.3",
     "eslint": "4.19.x",
     "eslint-plugin-html": "4.0.x",
-    "eslint-plugin-import": "2.12.x",
+    "eslint-plugin-import": "2.13.x",
     "eslint-plugin-json": "1.2.x",
-    "eslint-plugin-node": "6.0.x",
+    "eslint-plugin-node": "7.0.x",
     "eslint-plugin-promise": "3.8.x",
     "eslint-plugin-standard": "3.1.x",
     "express": "4.16.x",
@@ -83,6 +83,7 @@
     "bcrypt-nodejs": "0.0.3",
     "bluebird": "3.5.1",
     "debug": "3.1.0",
+    "hbs-utils": "0.0.4",
     "jsonwebtoken": "8.3.0"
   }
 }

--- a/server/app.js
+++ b/server/app.js
@@ -1,5 +1,7 @@
 const bodyParser = require('body-parser');
 const express = require('express');
+const hbs = require('hbs');
+const hbsUtils = require('hbs-utils')(hbs);
 const path = require('path');
 const warpjsUtils = require('@warp-works/warpjs-utils');
 
@@ -14,6 +16,19 @@ module.exports = (config, warpCore, Persistence, baseUrl, staticUrl) => {
 
     app.set('view engine', 'hbs');
     app.set('views', warpjsUtils.getHandlebarsViewsDir());
+
+    const handlebarsPartialsDir = warpjsUtils.getHandlebarsPartialsDir();
+    hbsUtils.registerWatchedPartials(
+        handlebarsPartialsDir,
+        {
+            precompile: true,
+            name: (template) => {
+                const newTemplateName = template.replace(/_/g, '-');
+                return newTemplateName;
+            }
+        }
+    );
+
     app.set('base-url', baseUrl);
     app.set('static-url', staticUrl);
     app.set('warpjs-config', config);

--- a/server/login/get.js
+++ b/server/login/get.js
@@ -9,7 +9,7 @@ module.exports = (req, res) => {
         html: () => {
             const baseUrl = req.app.get('base-url');
 
-            warpjsUtils.sendIndex(res, 'Login',
+            warpjsUtils.sendPortalIndex(req, res, RoutesInfo, 'Login',
                 [
                     `${baseUrl}/assets/${libConstants.assets.js}`
                 ],

--- a/server/login/get.unit.test.js
+++ b/server/login/get.unit.test.js
@@ -2,7 +2,6 @@ const testHelpers = require('@quoin/node-test-helpers');
 const RoutesInfoCache = require('@quoin/expressjs-routes-info/lib/cache');
 const warpjsUtils = require('@warp-works/warpjs-utils');
 
-const app = require('./../app');
 const constants = require('./../constants');
 const libConstants = require('./../../lib/constants');
 const moduleToTest = require('./get');
@@ -11,15 +10,9 @@ const specUtils = require('./../utils.helpers.test');
 const expect = testHelpers.expect;
 
 describe("server/login/get", () => {
-    const config = {};
-    const warpCore = {};
-    const Persistence = {};
-    const baseUrl = '/test';
-    const staticUrl = '/test-static';
-
     beforeEach(() => {
         RoutesInfoCache.reset();
-        app(config, warpCore, Persistence, baseUrl, staticUrl);
+        specUtils.initApp();
     });
 
     it("should expose a function with 2 params", () => {
@@ -58,16 +51,33 @@ describe("server/login/get", () => {
         moduleToTest(req, res);
 
         expect(res._getStatusCode()).to.equal(200);
-        expect(res._getRenderView()).to.equal('index');
-        expect(res._getRenderData()).to.deep.equal({
-            title: "Login",
-            baseUrl: 'base-url',
-            staticUrl: 'static-url',
-            bundles: [
-                `base-url/assets/${libConstants.assets.js}`
-            ],
-            cssFile: `base-url/assets/${libConstants.assets.css}`
-        });
+        expect(res._getRenderView()).to.equal('portal-index');
+
+        const renderData = res._getRenderData();
+        expect(renderData).has.property('baseUrl', 'base-url');
+        expect(renderData).has.property('staticUrl', 'static-url');
+        expect(renderData).has.property('title', "Login");
+        expect(renderData).has.property('copyrightYear', (new Date()).getFullYear());
+
+        expect(renderData).has.property('bundles');
+        expect(renderData.bundles).to.deep.equal([
+            `base-url/assets/${libConstants.assets.js}`
+        ]);
+
+        expect(renderData).has.property('cssFile', `base-url/assets/${libConstants.assets.css}`);
+
+        expect(renderData).has.property('warpjsFeatures');
+        expect(renderData.warpjsFeatures).to.be.an('object');
+
+        expect(renderData).has.property('warpjsUser');
+
+        expect(renderData).has.property('_embedded');
+        expect(renderData._embedded).has.property('headerItems');
+
+        expect(renderData).has.property('_links');
+        expect(renderData._links).has.property('warpjsLogo');
+        expect(renderData._links).has.property('warpjsLogin');
+        expect(renderData._links).has.property('warpjsLogout');
     });
 
     describe("in HAL", () => {

--- a/server/middlewares/requires-warpjs-user.unit.test.js
+++ b/server/middlewares/requires-warpjs-user.unit.test.js
@@ -2,9 +2,9 @@ const RoutesInfo = require('@quoin/expressjs-routes-info');
 const RoutesInfoCache = require('@quoin/expressjs-routes-info/lib/cache');
 const testHelpers = require('@quoin/node-test-helpers');
 
-const app = require('./../app');
 const constants = require('./../constants');
 const moduleToTest = require('./requires-warpjs-user');
+const specHelpers = require('./../utils.helpers.test');
 
 const expect = testHelpers.expect;
 
@@ -12,16 +12,10 @@ describe("server/middlewares/requires-warpjs-user", () => {
     const config = {};
     const warpCore = {};
     const Persistence = {};
-    const baseUrl = '/test';
-    const staticUrl = '/test-static';
 
     beforeEach(() => {
-        const config = {};
-        const warpCore = {};
-        const Persistence = {};
-
         RoutesInfoCache.reset();
-        app(config, warpCore, Persistence, baseUrl, staticUrl);
+        specHelpers.initApp();
     });
 
     it("should expose a function with 6 params", () => {

--- a/server/utils.helpers.test.js
+++ b/server/utils.helpers.test.js
@@ -1,10 +1,16 @@
 const _ = require('lodash');
 const testHelpers = require('@quoin/node-test-helpers');
 const Persistence = require('@warp-works/warpjs-mongo-persistence'); // FIXME: Create a mock-persistence
-
-const app = require('./app');
+const RoutesInfo = require('@quoin/expressjs-routes-info');
+const warpjsUtils = require('@warp-works/warpjs-utils');
 
 const expect = testHelpers.expect;
+const proxyquire = testHelpers.proxyquire.noCallThru().noPreserveCache();
+const app = proxyquire(require.resolve('./app'), {
+    'hbs-utils': () => ({
+        registerWatchedPartials: () => {}
+    })
+});
 
 const EXPECTED_COPYRIGHT_YEAR = (new Date()).getFullYear();
 
@@ -25,6 +31,16 @@ function verifyHal(expect, data) {
 }
 
 function initApp(config = {}, warpCore = {}) {
+    const routesInfo = new RoutesInfo('/sub-path', '/base-url');
+    routesInfo.route('entity', '/entity-path/type/{type}/id/{id}');
+
+    warpjsUtils.cache.setConfig({
+        headerItems: [{
+            label: "Foo Bar",
+            type: "FooBar",
+            id: "123123123123"
+        }]
+    });
     return app(config, warpCore, Persistence, '/test', '/static-test');
 }
 


### PR DESCRIPTION
Work to make the header/footer dynamic so that it updates when warpjs-utils updates them.